### PR TITLE
Remove metadata from log when empty

### DIFF
--- a/lib/winston-winlog2.js
+++ b/lib/winston-winlog2.js
@@ -36,7 +36,7 @@ EventLog.prototype.log = function (level, msg, meta, callback) {
 	}
 	var that = this;
 	var message = msg;
-	if ( meta ) {
+	if ( meta && Object.keys(meta).length > 0 ) {
 		try {
 			message += " metadata: " + circularJson.stringify(meta, null, 2);
 		}


### PR DESCRIPTION
Remove the metadata object from the log message when empty.

Currently, the log is like this:
My log message metadata: {}

Now you just have your log message when there is no additional metadata.
